### PR TITLE
[ DAAI-53 | ISSUES #15 ] - Fix cdn url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@doctorassistant/daai-component",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@doctorassistant/daai-component",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "dexie": "^4.0.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorassistant/daai-component",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A custom web component for a recording",
   "main": "dist/DaaiBadge.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -168,7 +168,7 @@ Caso a sua aplicação não utilize react, vue.js e angular, você pode optar po
     <title>Document</title>
     // aqui você deve chamar por meio do cdn dentro do script
     <script
-      src="https://cdn.jsdelivr.net/npm/@doctorassistant/daai-component/dist/DaaiBadge.js"
+      src="https://cdn.jsdelivr.net/npm/@doctorassistant/daai-component@latest/dist/DaaiBadge.js"
       type="module"
     ></script>
   </head>
@@ -187,7 +187,7 @@ Caso a sua aplicação não utilize react, vue.js e angular, você pode optar po
 ```html
 Versão mais atualizada
 <script
-  src="https://cdn.jsdelivr.net/npm/@doctorassistant/daai-component/dist/DaaiBadge.js"
+  src="https://cdn.jsdelivr.net/npm/@doctorassistant/daai-component@latest/dist/DaaiBadge.js"
   type="module"
 ></script>
 Versão especificada


### PR DESCRIPTION
### Descreva a mudança feita: 
<!-- o que foi mudado no código? -->
Resolução da [Issues](https://github.com/doctor-assistant/daai-component/issues/15#issue-2609703936) que relatou um problema na url para conseguir a versão latest do nosso componente.

esse  PR corrige esse problema. 

### Como essa mudança deve ser testada?
O teste deve ser feito da seguinte forma, para usar o nosso componente via cdn com a versão latest você deve utilizar a url 

```
<script
  src="https://cdn.jsdelivr.net/npm/@doctorassistant/daai-component@latest/dist/DaaiBadge.js"
  type="module"
></script>
```


<!-- descreva como realizar o teste -->


### Motivo da mudança
- [ ] resolução de bugs
- [ ] refatoração
- [ ] nova feature 
- [ ] necessidade de negócio 
- [ ] mudanças na estilização
- [ ] instalação de novos pacotes e dependências
- [ ] testes automatizados
- [x] mudança no readme