### PR TITLE
[ DAAI-55 | ISSUES #17 ] - Add the metadata send field for return in the webhook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@doctorassistant/daai-component",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@doctorassistant/daai-component",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
         "dexie": "^4.0.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorassistant/daai-component",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "A custom web component for a recording",
   "main": "dist/DaaiBadge.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,21 @@ apikey = 'aqui você deve passar a chave da api para realizar as requisições';
 // ⚠️ A propriedade modeApi é obrigatória para definir se você deseja utilizar o ambiente de teste você deve passar o valor 'dev', caso você queira testar o ambiente de produção você deve passar o valor 'prod', caso você não passe essa propriedade, o componente não irá fazer requisições.
 modeApi = 'dev';
 // ⚠️ A propriedade specialty não é obrigatória, o componente irá funcionar normalmente caso você não passe essa chave, caso ela não seja passada o usuário pode selecionar a especialidade desejada no select.
-specialty='aqui você deve passar a especialidade que você quer que o usuário use"
+specialty =
+  'aqui você deve passar a especialidade que você quer que o usuário use';
+// ⚠️ A propriedade metadata não é obrigatória, o componente irá funcionar normalmente caso você não passe essa chave, no entanto, a chave serve para enviar dados que você deseja recuperar posteriormente pela nossa API quando a gravação for finalizada, possibilitando a recuperação por meio do webhook.
+metadata =
+  'aqui você deve passar o valor que deseja recuperar, se atente ao formato, descrevo no tópico abaixo.';
+```
+
+### Formato metadata
+
+```html
+// ⚠️ Essse deve ser o formato
+<body>
+  <daai-component metadata='{"name": "doctor", "role": "Assistant"}'>
+  </daai-component>
+</body>
 ```
 
 ## customização

--- a/src/DaaiBadge.js
+++ b/src/DaaiBadge.js
@@ -45,6 +45,7 @@ class DaaiBadge extends HTMLElement {
     this.professionalId = '';
     this.specialty = 'generic';
     this.modeApi = '';
+    this.metadata = {};
 
     this.upload = () => blockPageReload();
     // Aqui criamos a shadow dom
@@ -432,6 +433,7 @@ class DaaiBadge extends HTMLElement {
       'professionalId',
       'modeApi',
       'specialty',
+      'metadata',
     ];
   }
 
@@ -439,6 +441,16 @@ class DaaiBadge extends HTMLElement {
     const successAttr = this.getAttribute('onSuccess');
     const errorAttr = this.getAttribute('onError');
     const specialtyProp = this.getAttribute('specialty');
+    const metadataProp = this.getAttribute('metadata');
+
+    if (metadataProp) {
+      try {
+        this.metadata = JSON.parse(metadataProp);
+      } catch (error) {
+        this.metadata = {};
+      }
+    }
+
     if (specialtyProp) {
       this.specialty = specialtyProp;
     } else {

--- a/src/api/Api.js
+++ b/src/api/Api.js
@@ -4,7 +4,8 @@ export async function uploadAudio(
   onSuccess,
   onError,
   specialty,
-  modeApi
+  modeApi,
+  metadata
 ) {
   const url =
     modeApi === 'dev' && modeApi !== 'prod'
@@ -14,6 +15,7 @@ export async function uploadAudio(
   const formData = new FormData();
   formData.append('recording', audioBlob);
   formData.append('specialty', specialty);
+  formData.append('metadata', JSON.stringify(metadata));
 
   try {
     const response = await fetch(url, {

--- a/src/scripts/RecorderUtils.js
+++ b/src/scripts/RecorderUtils.js
@@ -163,7 +163,8 @@ export function finishRecording() {
           this.onSuccess,
           this.onError,
           this.specialty,
-          this.modeApi
+          this.modeApi,
+          this.metadata
         );
         await professionalDb.audio.add({
           professionalId: this.professionalId,


### PR DESCRIPTION

### Descreva a mudança feita: 
<!-- o que foi mudado no código? -->
Resolução da [Issues](https://github.com/doctor-assistant/daai-component/issues/17) que relatou uma necessidade de adicionar uma propriedade capaz de ser enviada por meio da requisição, sendo possível recupera-lá através do webwook. 

Adição de um prop chamada `metadata` que envia essa informação para a api.

esse  PR corrige esse problema. 

### Como essa mudança deve ser testada?
O teste deve ser feito da seguinte forma, enviar um objeto por meio da propriedade metadata no nosso componente e verificar se ele está presente no corpo da requisição.

[⚠️](https://emojipedia.org/warning) as chaves são de sua escolha

Exemplo:
```
<daai-component metadata='{"name": "doctor", "role": "Assistant"}'>
</daai-component>
```


<!-- descreva como realizar o teste -->


### Motivo da mudança
- [ ] resolução de bugs
- [ ] refatoração
- [ ] nova feature 
- [x] necessidade de negócio 
- [ ] mudanças na estilização
- [ ] instalação de novos pacotes e dependências
- [ ] testes automatizados
- [x] mudança no readme